### PR TITLE
fix backend structure and advice in backend/frontend

### DIFF
--- a/backend/src/assignments/assignments.service.ts
+++ b/backend/src/assignments/assignments.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { mockAssignments } from '../../mocks/assignments.mock';
+import { mockAssignments } from '@/mocks/assignments.mock';
 
 @Injectable()
 export class AssignmentsService {

--- a/backend/src/courses/courses.controller.ts
+++ b/backend/src/courses/courses.controller.ts
@@ -1,6 +1,6 @@
 import { CoursesService } from './courses.service';
 import { Controller, Get, Post, Param, Put, Delete, Body, ParseIntPipe } from '@nestjs/common';
-import { Course } from '../common/interfaces/course.interface';
+import type { Course } from '@/common/interfaces/course.interface';
 
 @Controller('courses')
 export class CoursesController {

--- a/backend/src/courses/courses.service.ts
+++ b/backend/src/courses/courses.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { mockCourses } from '../../mocks/courses.mock';
-import { Course } from '../common/interfaces/course.interface';
+import { mockCourses } from '@/mocks/courses.mock';
+import { Course } from '@/common/interfaces/course.interface';
 
 @Injectable()
 export class CoursesService {

--- a/backend/src/mocks/assignments.mock.ts
+++ b/backend/src/mocks/assignments.mock.ts
@@ -1,4 +1,4 @@
-import { Assignment } from '../src/common/interfaces/assignment.interface';
+import { Assignment } from '@/common/interfaces/assignment.interface';
 
 export const mockAssignments: Assignment[] = [
   {

--- a/backend/src/mocks/courses.mock.ts
+++ b/backend/src/mocks/courses.mock.ts
@@ -1,4 +1,4 @@
-import { Course } from '../src/common/interfaces/course.interface';
+import { Course } from '@/common/interfaces/course.interface';
 
 export const mockCourses: Course[] = [
   {

--- a/backend/src/mocks/projects.mock.ts
+++ b/backend/src/mocks/projects.mock.ts
@@ -1,4 +1,4 @@
-import { Project } from '../src/common/interfaces/project.interface';
+import { Project } from '@/common/interfaces/project.interface';
 
 export const mockProjects: Project[] = [
   {

--- a/backend/src/mocks/users.mock.ts
+++ b/backend/src/mocks/users.mock.ts
@@ -1,4 +1,4 @@
-import { User } from '../src/common/interfaces/user.interface';
+import { User } from '@/common/interfaces/user.interface';
 
 export const mockUsers: User[] = [
   {

--- a/backend/src/projects/projects.controller.ts
+++ b/backend/src/projects/projects.controller.ts
@@ -1,6 +1,6 @@
 import { ProjectService } from './projects.service';
 import { Controller, Get, Post, Param, Put, Delete, Body, ParseIntPipe } from '@nestjs/common';
-import { Project } from '../common/interfaces/project.interface';
+import type { Project } from '@/common/interfaces/project.interface';
 
 @Controller('projects')
 export class ProjectController {

--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { mockProjects } from '../../mocks/projects.mock';
-import { Project } from '../common/interfaces/project.interface';
+import { mockProjects } from '@/mocks/projects.mock';
+import { Project } from '@/common/interfaces/project.interface';
 
 @Injectable()
 export class ProjectService {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,25 +1,28 @@
 {
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "./dist",
-    "module": "commonjs",
-    "target": "esnext",
-    "types": ["node"],
-    "lib": ["esnext"],
-
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "resolvePackageJsonExports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2023",
     "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
-
-    "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
-
-    "strict": true,
-    "skipLibCheck": true
-  },
-  "include": ["src", "mocks"],
-  "exclude": ["node_modules", "dist", "build"]
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "noFallthroughCasesInSwitch": false,
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
 }


### PR DESCRIPTION
Это необходимо для фикса **докера** (будет создан отдельный PR для Dockerfile)
- `tsbuild.json` был настроен некорректно, не использовал определённые строгие правила по умолчанию, в результате чего докер падал, потому что точка собранного сервера вместо ожидаемого `dist/main.js` превратилась в `dist/src/main.js`.
- Поэтому я принял решение взять стандартный `tsconfig.json` из nest проекта, где корректно описаны настройки.
- Моки я перенёс в src, им не место в корне бэка, папка `src` для того и `src`, что там должен хранится **весь** код
- Добавил поддержку алиаса `@` в `tsbuild.json` - он нужен, чтобы указать, что путь начинается в src.
- Это очень удобно для читабельности, особенно для очень вложенной структуры - вместо того, чтобы пробиваться наверх через `../../../common/interfaces/`, вы просто пишите `@/common/interfaces`

Ниже для **бэка** ещё один совет (это изменение я не вношу, это больше на вас лежит)
Используйте `index.ts` barrel файлы для экспорта интерфейсов (только не для модулей nest.js, или каких-то огромных частей кода. там это очень хреновая практика приводящая к замедлению программы и сборки)\
Вот ссылка на статью: https://flaming.codes/ru/posts/barrel-files-in-javascript

Например, вместо того, чтобы писать
```ts
import type { Project } from '@/common/interfaces/project.interface';
import type { Assignment } from '@/common/interfaces/assignment.interface';
```

можно будет писать так:
```ts
import type { Project, Assignment } from '@/common/interfaces';
```

Сам index.ts файл выглядит так:

```ts
export type { Project } from './project.interface';
export type { Course } from './course.interface';
export type { User } from './user.interface';
export type { Assignment } from './assignment.interface';
```

Согласитесь, куда проще читать
Можете добавить для моков и всё, что будет попадать в common папку (вы уже сами выбираете, что будет использоваться через импорт из папки)

Для **фронта** это тоже актуально, если надо экспортировать `vue` файлы с кнопочками, карточками (где нет огромной реализации каждого компонента)
Можно писать в index.ts что-то вроде (просто пример)
```ts
export { default as LanguageButton } from './LanguageButton.vue';
export { default as LogOutButton } from './LogOutButton.vue';
export { default as ThemeModeButton } from './ThemeModeDropdownButton.vue';
```

А в другом файле писать:
```ts
import { LanguageButton, LogOutButton, ThemeModeButton } from '@/shared/ui/components/button';
```
