### PR TITLE
fix typescript in vue.js files

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,16 +19,29 @@ export default defineConfig([
   // базовые правила для Vue.js
   ...pluginVue.configs['flat/recommended'],
   globalIgnores(['node_modules/**', 'dist/**', 'build/**', 'coverage/**']),
+  // корректный парсинг TypeScript внутри Vue SFC
+  {
+    files: ['**/*.vue'],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: {
+        parser: '@typescript-eslint/parser',
+        extraFileExtensions: ['.vue'],
+        sourceType: 'module',
+      },
+      globals: {
+        ...globals.browser,
+      },
+    },
+  },
   // frontend
   {
-    files: ['frontend/**/*.{ts,tsx,vue,mts}'],
+    basePath: 'frontend',
+    files: ['**/*.{ts,tsx,mts}'],
     languageOptions: {
-      // используем парсер для Vue.js, который поддерживает TypeScript
-      parser: vueParser,
-      // указываем опции парсера для Vue.js и TypeScript
+      parser: tseslint.parser,
       parserOptions: {
-        parser: tseslint.parser,
-        extraFileExtensions: ['.vue'],
+        parser: '@typescript-eslint/parser',
         sourceType: 'module',
       },
       globals: {
@@ -38,7 +51,8 @@ export default defineConfig([
   },
   // backend
   {
-    files: ['backend/**/*.{ts,tsx,mts}'],
+    basePath: 'backend',
+    files: ['**/*.{ts,tsx,mts}'],
     languageOptions: {
       // используем парсер TypeScript ESLint для бэкенда
       parser: tseslint.parser,
@@ -59,7 +73,8 @@ export default defineConfig([
     },
   },
   {
-    files: ['database/**/*.{ts,mts}'],
+    basePath: 'database',
+    files: ['**/*.{ts,mts}'],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {


### PR DESCRIPTION
В vue.js файлах парсер некорректно себя вёл, из-за этого падает проверка CI на vue.js файлах.